### PR TITLE
Add macroeconomic comparison notebook

### DIFF
--- a/macro_analysis.ipynb
+++ b/macro_analysis.ipynb
@@ -1,0 +1,269 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ef109dd1",
+   "metadata": {},
+   "source": [
+    "## Instalação das Bibliotecas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d0cf882",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install pandas requests plotly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7349cc7c",
+   "metadata": {},
+   "source": [
+    "## Importação das bibliotecas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "428f631e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import requests\n",
+    "import plotly.express as px\n",
+    "import plotly.graph_objs as go"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44d436bf",
+   "metadata": {},
+   "source": [
+    "## Função para coletar dados do Banco Central do Brasil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ecca2b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def bcb_data(serie, start=\"01/01/2010\", end=None):\n",
+    "    \"\"\"Busca dados da API do Banco Central do Brasil.\n",
+    "    \n",
+    "    Parametros:\n",
+    "        serie (str | int): codigo da serie (ex. 4189 para Selic meta).\n",
+    "        start (str): data inicial dd/mm/aaaa.\n",
+    "        end (str | None): data final dd/mm/aaaa.\n",
+    "    \"\"\"\n",
+    "    url = f\"https://api.bcb.gov.br/dados/serie/bcdata.sgs.{serie}/dados\"\n",
+    "    params = {\"formato\": \"json\", \"dataInicial\": start}\n",
+    "    if end:\n",
+    "        params[\"dataFinal\"] = end\n",
+    "    r = requests.get(url, params=params, timeout=30)\n",
+    "    if r.status_code != 200:\n",
+    "        raise ValueError(f\"Erro {r.status_code} ao acessar {url}\")\n",
+    "    df = pd.DataFrame(r.json())\n",
+    "    df[\"data\"] = pd.to_datetime(df[\"data\"], dayfirst=True)\n",
+    "    df[\"valor\"] = pd.to_numeric(df[\"valor\"], errors=\"coerce\")\n",
+    "    df = df.dropna()\n",
+    "    return df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab2dba7a",
+   "metadata": {},
+   "source": [
+    "## Função para coletar dados do FRED (EUA)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73eea8cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def fred_data(series_id, api_key, start=\"2010-01-01\", end=None):\n",
+    "    \"\"\"Busca dados de uma série do FRED.\n",
+    "    \n",
+    "    Parametros:\n",
+    "        series_id (str): identificador da série no FRED.\n",
+    "        api_key (str): chave de acesso.\n",
+    "        start (str): data inicial AAAA-MM-DD.\n",
+    "        end (str | None): data final AAAA-MM-DD.\n",
+    "    \"\"\"\n",
+    "    url = \"https://api.stlouisfed.org/fred/series/observations\"\n",
+    "    params = {\n",
+    "        \"series_id\": series_id,\n",
+    "        \"api_key\": api_key,\n",
+    "        \"file_type\": \"json\",\n",
+    "        \"observation_start\": start\n",
+    "    }\n",
+    "    if end:\n",
+    "        params[\"observation_end\"] = end\n",
+    "    r = requests.get(url, params=params, timeout=30)\n",
+    "    if r.status_code != 200:\n",
+    "        raise ValueError(f\"Erro {r.status_code} ao acessar {url}\")\n",
+    "    data = r.json().get(\"observations\", [])\n",
+    "    if not data:\n",
+    "        raise ValueError(\"Nenhum dado retornado\")\n",
+    "    df = pd.DataFrame(data)\n",
+    "    df[\"date\"] = pd.to_datetime(df[\"date\"])\n",
+    "    df[\"value\"] = pd.to_numeric(df[\"value\"], errors=\"coerce\")\n",
+    "    df = df.dropna()\n",
+    "    return df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93248d6d",
+   "metadata": {},
+   "source": [
+    "## Obtenção dos dados"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44e86536",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "FRED_API_KEY = \"COLE_SUA_API_KEY_AQUI\"  # substitua pela sua chave FRED\n",
+    "\n",
+    "selic = bcb_data(4189, start=\"2015-01-01\")\n",
+    "fedfunds = fred_data(\"FEDFUNDS\", FRED_API_KEY, start=\"2015-01-01\")\n",
+    "\n",
+    "ipca = bcb_data(433, start=\"2015-01-01\")\n",
+    "cpi = fred_data(\"CPIAUCSL\", FRED_API_KEY, start=\"2015-01-01\")\n",
+    "\n",
+    "dolar_bcb = bcb_data(1, start=\"2015-01-01\")\n",
+    "dolar_fred = fred_data(\"DEXBZUS\", FRED_API_KEY, start=\"2015-01-01\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad3a2176",
+   "metadata": {},
+   "source": [
+    "## Alinhamento temporal dos dados"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40549d1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "df_rates = pd.merge(\n",
+    "    selic.resample(\"M\", on=\"data\").last().rename(columns={\"valor\": \"selic\"}),\n",
+    "    fedfunds.resample(\"M\", on=\"date\").last().rename(columns={\"value\": \"fedfunds\"}),\n",
+    "    left_index=True,\n",
+    "    right_index=True,\n",
+    "    how=\"inner\"\n",
+    ")\n",
+    "\n",
+    "df_inflation = pd.merge(\n",
+    "    ipca.rename(columns={\"data\": \"date\", \"valor\": \"ipca\"}),\n",
+    "    cpi.rename(columns={\"value\": \"cpi\"}),\n",
+    "    on=\"date\",\n",
+    "    how=\"inner\"\n",
+    ")\n",
+    "\n",
+    "df_fx = pd.merge(\n",
+    "    dolar_bcb.resample(\"D\", on=\"data\").last().rename(columns={\"valor\": \"brl_bcb\"}),\n",
+    "    dolar_fred.resample(\"D\", on=\"date\").last().rename(columns={\"value\": \"brl_fred\"}),\n",
+    "    left_index=True,\n",
+    "    right_index=True,\n",
+    "    how=\"inner\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "daccdc84",
+   "metadata": {},
+   "source": [
+    "## Gráficos Interativos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8efb3946",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "fig_rates = go.Figure()\n",
+    "fig_rates.add_trace(go.Scatter(x=df_rates.index, y=df_rates['selic'], mode='lines', name='Selic (%)'))\n",
+    "fig_rates.add_trace(go.Scatter(x=df_rates.index, y=df_rates['fedfunds'], mode='lines', name='Fed Funds (%)'))\n",
+    "fig_rates.update_layout(title='Taxas de Juros Brasil x EUA', xaxis_title='Data', yaxis_title='Taxa (%)')\n",
+    "\n",
+    "fig_inflation = go.Figure()\n",
+    "fig_inflation.add_trace(go.Bar(x=df_inflation['date'], y=df_inflation['ipca'], name='IPCA'))\n",
+    "fig_inflation.add_trace(go.Bar(x=df_inflation['date'], y=df_inflation['cpi'], name='CPI'))\n",
+    "fig_inflation.update_layout(barmode='group', title='Inflação Mensal', xaxis_title='Data', yaxis_title='Variação (%)')\n",
+    "\n",
+    "fig_fx = go.Figure()\n",
+    "fig_fx.add_trace(go.Scatter(x=df_fx.index, y=df_fx['brl_bcb'], mode='lines', name='BCB USD/BRL'))\n",
+    "fig_fx.add_trace(go.Scatter(x=df_fx.index, y=df_fx['brl_fred'], mode='lines', name='FRED USD/BRL'))\n",
+    "fig_fx.update_layout(title='Taxa de câmbio USD/BRL', xaxis_title='Data', yaxis_title='Reais por Dólar')\n",
+    "\n",
+    "fig_rates.show()\n",
+    "fig_inflation.show()\n",
+    "fig_fx.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a992f8ac",
+   "metadata": {},
+   "source": [
+    "## Insights Automáticos (exemplo simples)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31150c76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "ultimo_selic = df_rates['selic'].iloc[-1]\n",
+    "ultimo_fed = df_rates['fedfunds'].iloc[-1]\n",
+    "if ultimo_selic > ultimo_fed:\n",
+    "    print('A Selic está acima do Fed Funds, indicando política monetária mais apertada no Brasil.')\n",
+    "else:\n",
+    "    print('O Fed Funds está acima da Selic, indicando política monetária mais apertada nos EUA.')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create `macro_analysis.ipynb` with sequential cells to fetch and visualize macroeconomic indicators from BCB and FRED

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c381b7788328841d7761f8de8201