### PR TITLE
Add BCB macro panel notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# Projeto-agora-vai
+# Projeto Agora Vai
+
+Este repositório contém notebooks de análise macroeconômica com dados do Banco Central do Brasil.
+
+## Arquivos
+
+- `bcb_macro_panel.ipynb` – painel interativo que coleta automaticamente Selic, IPCA, câmbio e PIB usando a API do BCB.
+- `macro_analysis.ipynb` – outros exemplos de análise econômica.
+
+Execute os notebooks em um ambiente Jupyter ou Google Colab.

--- a/bcb_macro_panel.ipynb
+++ b/bcb_macro_panel.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b81da245",
+   "metadata": {},
+   "source": [
+    "## Instalação das Bibliotecas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46fa8a04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install pandas requests plotly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74af2715",
+   "metadata": {},
+   "source": [
+    "## Importação das Bibliotecas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0eb91c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import requests\n",
+    "import plotly.express as px"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf549864",
+   "metadata": {},
+   "source": [
+    "## Função para coletar dados do Banco Central do Brasil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9690c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def coletar_bcb(codigo, data_inicial, data_final=None):\n",
+    "    \"\"\"Coleta dados do BCB via API.\"\"\"\n",
+    "    url = f\"https://api.bcb.gov.br/dados/serie/bcdata.sgs.{codigo}/dados\"\n",
+    "    params = {\"formato\": \"json\", \"dataInicial\": data_inicial}\n",
+    "    if data_final:\n",
+    "        params[\"dataFinal\"] = data_final\n",
+    "    try:\n",
+    "        resp = requests.get(url, params=params, timeout=30)\n",
+    "        resp.raise_for_status()\n",
+    "    except requests.RequestException as e:\n",
+    "        raise SystemExit(f\"Erro ao acessar API: {e}\")\n",
+    "    df = pd.DataFrame(resp.json())\n",
+    "    df[\"data\"] = pd.to_datetime(df[\"data\"], dayfirst=True)\n",
+    "    df[\"valor\"] = pd.to_numeric(df[\"valor\"], errors='coerce')\n",
+    "    df = df.dropna()\n",
+    "    return df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8a0c281",
+   "metadata": {},
+   "source": [
+    "## Coleta dos Indicadores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73921679",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "selic = coletar_bcb(4189, '01/01/2015')\n",
+    "ipca = coletar_bcb(433, '01/01/2015')\n",
+    "fx = coletar_bcb(1, '01/01/2015')\n",
+    "pib = coletar_bcb(4380, '01/01/2015')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1adc0378",
+   "metadata": {},
+   "source": [
+    "## Visualizações Interativas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f8ad3f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "fig_selic = px.line(selic, x='data', y='valor', title='Taxa Selic Meta')\n",
+    "fig_selic.update_layout(xaxis_title='Data', yaxis_title='% ao ano')\n",
+    "fig_selic.show()\n",
+    "\n",
+    "fig_ipca = px.bar(ipca, x='data', y='valor', title='IPCA Mensal')\n",
+    "fig_ipca.update_layout(xaxis_title='Data', yaxis_title='% ao mês')\n",
+    "fig_ipca.show()\n",
+    "\n",
+    "fig_fx = px.line(fx, x='data', y='valor', title='Câmbio USD/BRL')\n",
+    "fig_fx.update_layout(xaxis_title='Data', yaxis_title='Reais por Dólar')\n",
+    "fig_fx.show()\n",
+    "\n",
+    "fig_pib = px.bar(pib, x='data', y='valor', title='PIB Trimestral (R$ bilhões)')\n",
+    "fig_pib.update_layout(xaxis_title='Data', yaxis_title='R$ bilhões')\n",
+    "fig_pib.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a799f1c",
+   "metadata": {},
+   "source": [
+    "## Análise Automática Simples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d13e69a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "print('Última Selic registrada:', selic.iloc[-1]['valor'])\n",
+    "print('Último IPCA mensal:', ipca.iloc[-1]['valor'])\n",
+    "print('Último câmbio USD/BRL:', fx.iloc[-1]['valor'])\n",
+    "print('Último PIB trimestral (R$ bi):', pib.iloc[-1]['valor'])\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a notebook to build a macroeconomic panel using the BCB API
- document available notebooks in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c672bdc88328a431013167ef7eda